### PR TITLE
Remove x32 platform build for Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,15 +41,9 @@ environment:
     # Stable 64-bit MSVC
     - channel: stable
       target: x86_64-pc-windows-msvc
-    # Stable 32-bit MSVC
-    - channel: stable
-      target: i686-pc-windows-msvc
     # Beta 64-bit MSVC
     - channel: beta
       target: x86_64-pc-windows-msvc
-    # Beta 32-bit MSVC
-    - channel: beta
-      target: i686-pc-windows-msvc
 
 # Only build against the branches that will have pull requests built against them (master).
 # Otherwise creating feature branches on this repository and a pull requests against them will


### PR DESCRIPTION
Clang used in Appveyor doesn't provided for 32 bits